### PR TITLE
Update ViewHolder visibility

### DIFF
--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -556,7 +556,7 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
         }
     }
 
-    protected abstract class ViewHolder extends RecyclerView.ViewHolder {
+    public abstract class ViewHolder extends RecyclerView.ViewHolder {
 
         public ViewHolder(View itemView) {
             super(itemView);


### PR DESCRIPTION
Set ViewHolder to _public_, so that we maintain the same visibility as RecyclerView's default ViewHolder implementation.