### PR TITLE
Footer/header layout params

### DIFF
--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -6,6 +6,7 @@ import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.util.DiffUtil;
+import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -56,6 +57,8 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     private UpdateItemsTask updateItemsTask;
 
     protected boolean isLoading = false;
+
+    private RecyclerView.LayoutManager layoutManager;
 
     public MjolnirRecyclerAdapter(Context context, Collection<E> list) {
         this.context = context;
@@ -410,10 +413,18 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
      * @param view View for which we want to set default layout params.
      */
     private void setDefaultLayoutParams(View view) {
-        if (view.getLayoutParams() == null) {
-            RecyclerView.LayoutParams lp = new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT,
-                    RecyclerView.LayoutParams.WRAP_CONTENT);
-            view.setLayoutParams(lp);
+        if (getLayoutManager() != null && getLayoutManager() instanceof LinearLayoutManager) {
+            RecyclerView.LayoutParams layoutParams;
+
+            if (((LinearLayoutManager) getLayoutManager()).getOrientation() == LinearLayoutManager.VERTICAL) {
+                layoutParams = new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT,
+                        RecyclerView.LayoutParams.WRAP_CONTENT);
+                view.setLayoutParams(layoutParams);
+            } else {
+                layoutParams = new RecyclerView.LayoutParams(RecyclerView.LayoutParams.WRAP_CONTENT,
+                        RecyclerView.LayoutParams.MATCH_PARENT);
+                view.setLayoutParams(layoutParams);
+            }
         }
     }
 
@@ -468,6 +479,7 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
      * the {@link #setDefaultLayoutParams(View)} method.
      *
      * If header already exists, it will be replaced depending on the {@param shouldReplace} value.
+     *
      * @param headerView    layout view
      * @param shouldReplace should we replace header if it already exists
      * @return true if header was added/replaced, false otherwise.
@@ -550,6 +562,14 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
 
     public void setNextPageOffset(int nextPageOffset) {
         this.nextPageOffset = nextPageOffset;
+    }
+
+    public RecyclerView.LayoutManager getLayoutManager() {
+        return layoutManager;
+    }
+
+    public void setLayoutManager(RecyclerView.LayoutManager layoutManager) {
+        this.layoutManager = layoutManager;
     }
 
     // endregion

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -382,7 +382,9 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     }
 
     /**
-     * Add a footer view to this adapter. If footer already exists, it will be replaced depending on the {@param shouldReplace} value.
+     * Add a footer view to this adapter. If layout params for the {@param footerView}} are missing, default layout params will be set with
+     * the {@link #setDefaultLayoutParams(View)} method.
+     * If footer already exists, it will be replaced depending on the {@param shouldReplace} value.
      *
      * @param footerView    layout view
      * @param shouldReplace should we replace footer if it already exists
@@ -393,10 +395,25 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
             removeFooter();
             int position = getCollectionCount() + (hasHeader() ? 1 : 0);
             this.footerView = footerView;
+            setDefaultLayoutParams(this.footerView);
             notifyItemInserted(position);
             return true;
         } else {
             return false;
+        }
+    }
+
+    /**
+     * Sets the default layout params to the provided {@param view} if they are not yet set. Default params are MATCH_PARENT for layout
+     * width and WRAP_CONTENT for layout height.
+     *
+     * @param view View for which we want to set default layout params.
+     */
+    private void setDefaultLayoutParams(View view) {
+        if (view.getLayoutParams() == null) {
+            RecyclerView.LayoutParams lp = new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT,
+                    RecyclerView.LayoutParams.WRAP_CONTENT);
+            view.setLayoutParams(lp);
         }
     }
 
@@ -447,8 +464,10 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     }
 
     /**
-     * Add a header view to this adapter. If header already exists, it will be replaced depending on the {@param shouldReplace} value.
+     * Add a header view to this adapter. If layout params for the {@param headerView}} are missing, default layout params will be set with
+     * the {@link #setDefaultLayoutParams(View)} method.
      *
+     * If header already exists, it will be replaced depending on the {@param shouldReplace} value.
      * @param headerView    layout view
      * @param shouldReplace should we replace header if it already exists
      * @return true if header was added/replaced, false otherwise.
@@ -457,6 +476,7 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
         if (shouldReplace || !hasHeader()) {
             removeHeader();
             this.headerView = headerView;
+            setDefaultLayoutParams(this.headerView);
             notifyItemInserted(0);
             return true;
         } else {

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerView.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerView.java
@@ -72,6 +72,16 @@ public class MjolnirRecyclerView extends RecyclerView {
         }
     }
 
+    @Override
+    public void setLayoutManager(LayoutManager layout) {
+        super.setLayoutManager(layout);
+
+        if (getAdapter() != null && getAdapter() instanceof MjolnirRecyclerAdapter
+                && ((MjolnirRecyclerAdapter) getAdapter()).getLayoutManager() == null) {
+            ((MjolnirRecyclerAdapter) getAdapter()).setLayoutManager(getLayoutManager());
+        }
+    }
+
     /**
      * Sets the RecyclerView's adapter and registers adapter data observer, which is used to update empty view's visibility and loading
      * state of the adapter.
@@ -85,6 +95,10 @@ public class MjolnirRecyclerView extends RecyclerView {
         super.setAdapter(adapter);
         if (adapter != null) {
             adapter.registerAdapterDataObserver(observer);
+        }
+
+        if (adapter instanceof MjolnirRecyclerAdapter && ((MjolnirRecyclerAdapter) getAdapter()).getLayoutManager() == null) {
+            ((MjolnirRecyclerAdapter) getAdapter()).setLayoutManager(getLayoutManager());
         }
 
         checkIfEmpty();


### PR DESCRIPTION
Set default layout params for footer and header views if the layout params are still not defined. Default layout params are MATCH_PARENT for layout's width and WRAP_CONTENT for layout's height.

This fixes the problem described in ticket #21.

@kjurkovic @ikocijan @reisub do you have any comments for the proposed solution?