### PR TITLE
Fix header/footer positioning for GridLayoutManager

### DIFF
--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -6,6 +6,7 @@ import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.util.DiffUtil;
+import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -335,6 +336,8 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
         }
     }
 
+    // region Headers and Footers
+
     /**
      * Add a footer to this adapter.
      * This method has higher priority than {@link #addFooter(android.view.View)}.
@@ -570,12 +573,34 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
 
     public void setLayoutManager(RecyclerView.LayoutManager layoutManager) {
         this.layoutManager = layoutManager;
+
+        // if layout manager is GridLayoutManager, we have to attach span size lookup in order to correctly setup header and footer view
+        if (layoutManager instanceof GridLayoutManager) {
+            setHeaderFooterViewsForGridLayoutManager((GridLayoutManager) layoutManager);
+        }
+    }
+
+    /**
+     * If adapter is using GridLayoutManager, we have to register custom SpanSizeLookup listener and manipulate with span size - if current
+     * item is either header or footer, we return {@param layoutManager} span count as span size in order to position header or footer view
+     * in it's own column.
+     *
+     * @param layoutManager GridLayoutManager for which we attach SpanSizeLookup listener.
+     */
+    private void setHeaderFooterViewsForGridLayoutManager(final GridLayoutManager layoutManager) {
+        layoutManager.setSpanSizeLookup(new GridLayoutManager.SpanSizeLookup() {
+            @Override
+            public int getSpanSize(int position) {
+                if (isHeader(position) || isFooter(position)) {
+                    return layoutManager.getSpanCount();
+                } else {
+                    return 1;
+                }
+            }
+        });
     }
 
     // endregion
-
-    // region Headers and Footers
-
 
     /**
      * @param position current adapter position

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
                 android:name=".activities.NextPageListenerActivity"
                 android:screenOrientation="portrait"/>
 
+        <activity
+                android:name=".activities.GridActivity"
+                android:screenOrientation="portrait"/>
+
     </application>
 
 </manifest>

--- a/testapp/src/main/java/co/infinum/testapp/activities/GridActivity.java
+++ b/testapp/src/main/java/co/infinum/testapp/activities/GridActivity.java
@@ -1,10 +1,8 @@
 package co.infinum.testapp.activities;
 
 import android.os.Bundle;
-import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.LinearLayoutManager;
 import android.view.View;
 import android.widget.Toast;
 
@@ -18,7 +16,11 @@ import co.infinum.mjolnirrecyclerview.MjolnirRecyclerView;
 import co.infinum.testapp.R;
 import co.infinum.testapp.adapters.SimpleAdapter;
 
-public class SimpleActivity extends AppCompatActivity implements SimpleAdapter.OnClickListener<String> {
+/**
+ * Created by Željko Plesac on 24/11/16.
+ */
+
+public class GridActivity extends AppCompatActivity implements SimpleAdapter.OnClickListener<String> {
 
     private static final List<String> ITEMS = Collections.unmodifiableList(Arrays.asList(
             "First",
@@ -47,34 +49,18 @@ public class SimpleActivity extends AppCompatActivity implements SimpleAdapter.O
         setContentView(R.layout.activity_simple);
         ButterKnife.bind(this);
 
-        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        recyclerView.setLayoutManager(new GridLayoutManager(this, 3));
         recyclerView.setEmptyView(emptyView);
 
         adapter = new SimpleAdapter(this);
         adapter.setOnClickListener(this);
+        adapter.addAll(ITEMS);
         recyclerView.setAdapter(adapter);
 
-        adapter.addHeader(R.layout.view_header, false);
-        adapter.addFooter(R.layout.view_footer, false);
+        View footerView = getLayoutInflater().inflate(R.layout.view_footer, null);
 
-        Handler handler = new Handler();
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                if (!isFinishing()) {
-                    adapter.addAll(ITEMS);
-                }
-            }
-        }, 5000);
-
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                if (!isFinishing()) {
-                    adapter.removeFooter();
-                }
-            }
-        }, 7000);
+        adapter.addHeader(R.layout.view_header, true);
+        adapter.addFooter(footerView, false);
     }
 
     @Override

--- a/testapp/src/main/java/co/infinum/testapp/activities/MainActivity.java
+++ b/testapp/src/main/java/co/infinum/testapp/activities/MainActivity.java
@@ -40,4 +40,10 @@ public class MainActivity extends AppCompatActivity {
         Intent intent = new Intent(this, UpdateActivity.class);
         startActivity(intent);
     }
+
+    @OnClick(R.id.button_grid)
+    void onGridExampleClick() {
+        Intent intent = new Intent(this, GridActivity.class);
+        startActivity(intent);
+    }
 }

--- a/testapp/src/main/res/layout/activity_main.xml
+++ b/testapp/src/main/res/layout/activity_main.xml
@@ -7,7 +7,6 @@
         android:gravity="center"
         tools:context="co.infinum.testapp.activities.MainActivity">
 
-
     <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -18,9 +17,17 @@
     <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:id="@+id/button_grid"
+            android:layout_below="@+id/button_simple"
+            android:layout_centerHorizontal="true"
+            android:text="@string/grid_example"/>
+
+    <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:layout_centerHorizontal="true"
-            android:layout_below="@+id/button_simple"
+            android:layout_below="@+id/button_grid"
             android:id="@+id/button_update"
             android:text="@string/example_update"/>
 

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="header">Example header</string>
     <string name="simple_example">Simple example</string>
     <string name="example_update">Example update</string>
+    <string name="grid_example">Grid example</string>
     <string name="update_content">Update content</string>
     <string name="loading">Loading...</string>
     <string name="example_scroll">Example next page listener</string>


### PR DESCRIPTION
If adapter uses GridLayoutManager, we have to manipulate layout's manager span size in order to correctly position header/footer view in it's separate row.

@kjurkovic @ikocijan leave your feedback when you'll have the time.

This fixes #23, and has to be merged after we merge #22.

