### PR TITLE
Extract view holders

### DIFF
--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirHeaderFooterView.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirHeaderFooterView.java
@@ -1,0 +1,16 @@
+package co.infinum.mjolnirrecyclerview;
+
+import android.view.View;
+
+import java.util.List;
+
+public class MjolnirHeaderFooterView<E> extends MjolnirViewHolder<E> {
+
+    public MjolnirHeaderFooterView(View itemView) {
+        super(itemView);
+    }
+
+    @Override
+    protected void bind(E item, int position, List<Object> payloads) {
+    }
+}

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirHeaderFooterViewHolder.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirHeaderFooterViewHolder.java
@@ -4,9 +4,9 @@ import android.view.View;
 
 import java.util.List;
 
-public class MjolnirHeaderFooterView<E> extends MjolnirViewHolder<E> {
+public class MjolnirHeaderFooterViewHolder<E> extends MjolnirViewHolder<E> {
 
-    public MjolnirHeaderFooterView(View itemView) {
+    public MjolnirHeaderFooterViewHolder(View itemView) {
         super(itemView);
     }
 

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -80,14 +80,14 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
      * Override if you need a custom implementation.
      */
     protected MjolnirViewHolder onCreateFooterViewHolder() {
-        return new MjolnirHeaderFooterView(footerView);
+        return new MjolnirHeaderFooterViewHolder(footerView);
     }
 
     /**
      * Override if you need a custom implementation.
      */
     protected MjolnirViewHolder onCreateHeaderViewHolder() {
-        return new MjolnirHeaderFooterView(headerView);
+        return new MjolnirHeaderFooterViewHolder(headerView);
 
     }
 

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -29,7 +29,7 @@ import java.util.List;
  * <p>
  * Created by Željko Plesac on 27/09/16.
  */
-public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<MjolnirRecyclerAdapter.ViewHolder> {
+public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<MjolnirViewHolder> {
 
     public static final int TYPE_HEADER = 111;
 
@@ -63,7 +63,7 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     }
 
     @Override
-    public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public MjolnirViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         // Check if we have to inflate ItemViewHolder of HeaderFooterHolder
         if (viewType == TYPE_ITEM) {
             return onCreateItemViewHolder(parent, viewType);
@@ -79,27 +79,27 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     /**
      * Override if you need a custom implementation.
      */
-    protected ViewHolder onCreateFooterViewHolder() {
-        return new HeaderFooterViewHolder(footerView);
+    protected MjolnirViewHolder onCreateFooterViewHolder() {
+        return new MjolnirHeaderFooterView(footerView);
     }
 
     /**
      * Override if you need a custom implementation.
      */
-    protected ViewHolder onCreateHeaderViewHolder() {
-        return new HeaderFooterViewHolder(headerView);
+    protected MjolnirViewHolder onCreateHeaderViewHolder() {
+        return new MjolnirHeaderFooterView(headerView);
 
     }
 
-    protected abstract ViewHolder onCreateItemViewHolder(ViewGroup parent, int viewType);
+    protected abstract MjolnirViewHolder onCreateItemViewHolder(ViewGroup parent, int viewType);
 
     @Override
-    public void onBindViewHolder(MjolnirRecyclerAdapter.ViewHolder holder, int position) {
+    public void onBindViewHolder(MjolnirViewHolder holder, int position) {
         onBindViewHolder(holder, position, Collections.emptyList());
     }
 
     @Override
-    public void onBindViewHolder(MjolnirRecyclerAdapter.ViewHolder holder, int position, List<Object> payloads) {
+    public void onBindViewHolder(MjolnirViewHolder holder, int position, List<Object> payloads) {
 
         //check what type of view our position is
         switch (getItemViewType(position)) {
@@ -236,7 +236,6 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
             notifyItemRemoved(calculateIndex(index, false));
         }
     }
-
 
     public E get(int index) {
         if (index >= items.size()) {
@@ -610,7 +609,6 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
         return TYPE_ITEM;
     }
 
-
     public interface OnClickListener<E> {
 
         void onClick(int index, E item);
@@ -647,25 +645,5 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
                 diffResult.dispatchUpdatesTo(adapterWeakReference.get());
             }
         }
-    }
-
-    public class HeaderFooterViewHolder extends ViewHolder {
-
-        public HeaderFooterViewHolder(View itemView) {
-            super(itemView);
-        }
-
-        @Override
-        protected void bind(E item, int position, List<Object> payloads) {
-        }
-    }
-
-    public abstract class ViewHolder extends RecyclerView.ViewHolder {
-
-        public ViewHolder(View itemView) {
-            super(itemView);
-        }
-
-        protected abstract void bind(E item, int position, List<Object> payloads);
     }
 }

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirViewHolder.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirViewHolder.java
@@ -1,0 +1,15 @@
+package co.infinum.mjolnirrecyclerview;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+import java.util.List;
+
+public abstract class MjolnirViewHolder<E> extends RecyclerView.ViewHolder {
+
+    public MjolnirViewHolder(View itemView) {
+        super(itemView);
+    }
+
+    protected abstract void bind(E item, int position, List<Object> payloads);
+}

--- a/testapp/src/main/java/co/infinum/testapp/adapters/SimpleAdapter.java
+++ b/testapp/src/main/java/co/infinum/testapp/adapters/SimpleAdapter.java
@@ -12,6 +12,7 @@ import java.util.List;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import co.infinum.mjolnirrecyclerview.MjolnirRecyclerAdapter;
+import co.infinum.mjolnirrecyclerview.MjolnirViewHolder;
 import co.infinum.testapp.R;
 
 /**
@@ -24,12 +25,22 @@ public class SimpleAdapter extends MjolnirRecyclerAdapter<String> {
     }
 
     @Override
-    protected MjolnirRecyclerAdapter<String>.ViewHolder onCreateItemViewHolder(ViewGroup parent, int viewType) {
+    protected MjolnirViewHolder<String> onCreateItemViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_adapter, parent, false);
-        return new ViewHolder(view);
+        return new TestViewHolder(view);
     }
 
-    public class ViewHolder extends MjolnirRecyclerAdapter<String>.ViewHolder {
+    @Override
+    public void onBindViewHolder(MjolnirViewHolder holder, int position) {
+        super.onBindViewHolder(holder, position);
+    }
+
+    @Override
+    public void onBindViewHolder(MjolnirViewHolder holder, int position, List<Object> payloads) {
+        super.onBindViewHolder(holder, position, payloads);
+    }
+
+    public class TestViewHolder extends MjolnirViewHolder<String> {
 
         @BindView(R.id.tv_position)
         TextView tvPosition;
@@ -40,7 +51,7 @@ public class SimpleAdapter extends MjolnirRecyclerAdapter<String> {
         @BindView(R.id.root_view)
         View rootView;
 
-        public ViewHolder(View itemView) {
+        public TestViewHolder(View itemView) {
             super(itemView);
             ButterKnife.bind(this, itemView);
         }

--- a/testapp/src/main/java/co/infinum/testapp/adapters/UpdateAdapter.java
+++ b/testapp/src/main/java/co/infinum/testapp/adapters/UpdateAdapter.java
@@ -13,6 +13,7 @@ import java.util.List;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import co.infinum.mjolnirrecyclerview.MjolnirRecyclerAdapter;
+import co.infinum.mjolnirrecyclerview.MjolnirViewHolder;
 import co.infinum.testapp.R;
 import co.infinum.testapp.diffutils.ItemsDiffUtil;
 import co.infinum.testapp.models.Item;
@@ -28,12 +29,12 @@ public class UpdateAdapter extends MjolnirRecyclerAdapter<Item> {
     }
 
     @Override
-    protected MjolnirRecyclerAdapter<Item>.ViewHolder onCreateItemViewHolder(ViewGroup parent, int viewType) {
+    protected MjolnirViewHolder<Item> onCreateItemViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_adapter, parent, false);
         return new ViewHolder(view);
     }
 
-    public class ViewHolder extends MjolnirRecyclerAdapter<Item>.ViewHolder {
+    public class ViewHolder extends MjolnirViewHolder<Item> {
 
         @BindView(R.id.tv_position)
         TextView tvPosition;

--- a/testapp/src/main/res/layout/activity_simple.xml
+++ b/testapp/src/main/res/layout/activity_simple.xml
@@ -10,7 +10,6 @@
             android:id="@+id/recycler_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_above="@+id/button_update"
     />
 
     <include


### PR DESCRIPTION
Extract view holders to separate files and refactor adapter in order to use them.

This solves the problem when we cannot override onBindViewHolder methods due to this error:

_error: name clash: onBindViewHolder(MjolnirRecyclerAdapter<Transaction>.ViewHolder,int,List<Object>) in TransactionsAdapter and onBindViewHolder(MjolnirRecyclerAdapter.ViewHolder,int,List<Object>) in MjolnirRecyclerAdapter have the same erasure, yet neither overrides the other_