### PR TITLE
Header and footer method visibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta1'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta3'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 22 16:52:47 CET 2016
+#Fri Jan 27 08:53:05 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -517,14 +517,14 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     /**
      * @return true if {@param footerView} is not null, false otherwise
      */
-    private boolean hasFooter() {
+    public boolean hasFooter() {
         return footerView != null;
     }
 
     /**
      * @return true if {@param headerView} is not null, false otherwise
      */
-    private boolean hasHeader() {
+    public boolean hasHeader() {
         return headerView != null;
     }
 


### PR DESCRIPTION
Change _hasHeader()_ and _hasFooter()_ method visibility to public. 

@ikocijan I know we talked about making them _protected_, but in that case - there is no way with which you can determine inside activity or fragment if MjolnirRecyclerView is showing header/footer view.