### PR TITLE
Support for multiple viewtypes, v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" } // needed for gradle-errorprone-plugin
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta3'
+        classpath 'com.android.tools.build:gradle:2.3.0-rc1'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -65,15 +65,14 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     @Override
     public MjolnirViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         // Check if we have to inflate ItemViewHolder of HeaderFooterHolder
-        if (viewType == TYPE_ITEM) {
-            return onCreateItemViewHolder(parent, viewType);
-        } else if (viewType == TYPE_HEADER) {
-            return onCreateHeaderViewHolder();
-        } else if (viewType == TYPE_FOOTER) {
-            return onCreateFooterViewHolder();
+        switch (viewType) {
+            case TYPE_HEADER:
+                return onCreateHeaderViewHolder();
+            case TYPE_FOOTER:
+                return onCreateFooterViewHolder();
+            default:
+                return onCreateItemViewHolder(parent, viewType);
         }
-
-        return null;
     }
 
     /**
@@ -103,7 +102,11 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
 
         //check what type of view our position is
         switch (getItemViewType(position)) {
-            case TYPE_ITEM:
+            case TYPE_HEADER:
+            case TYPE_FOOTER:
+                //Nothing, for now.
+                break;
+            default:
                 position = calculateIndex(position, true);
                 E item = items.get(position);
                 holder.bind(item, position, payloads);
@@ -113,9 +116,6 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
                     isLoading = true;
                     nextPageListener.onScrolledToNextPage();
                 }
-                break;
-            default:
-                //Nothing, for now.
                 break;
         }
     }
@@ -599,7 +599,6 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
      */
     @Override
     public int getItemViewType(int position) {
-
         //check what type our position is, based on the assumption that the order is headers > items > footers
         if (isHeader(position)) {
             return TYPE_HEADER;

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -606,16 +606,16 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
             return TYPE_FOOTER;
         }
 
-        return getCustomItemViewType(position);
+        return getAdditionalItemViewType(position);
     }
 
     /**
-     * +     * Override this method if you are using custom ItemViewType and provide correct implementation.
-     * +     * @param position
-     * +     * @return
+     * Override this method if you are using custom ItemViewType and provide correct implementation.
+     * @param position
+     * @return
      * +
      */
-    protected int getCustomItemViewType(int position) {
+    protected int getAdditionalItemViewType(int position) {
         return TYPE_ITEM;
     }
 

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -605,8 +605,20 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
         } else if (isFooter(position)) {
             return TYPE_FOOTER;
         }
+
+        return getCustomItemViewType(position);
+    }
+
+    /**
+     * +     * Override this method if you are using custom ItemViewType and provide correct implementation.
+     * +     * @param position
+     * +     * @return
+     * +
+     */
+    protected int getCustomItemViewType(int position) {
         return TYPE_ITEM;
     }
+
 
     public interface OnClickListener<E> {
 


### PR DESCRIPTION
Second proposed solution for multiple viewtypes:

* _getCustomItemViewType()_ for returning correct ViewType
* updates for _onBindViewHolder()_ and _onCreateViewHolder()_

To use this feature, user now has to override _getCustomItemViewType()_ and implement logic for returning correct viewtype, and override _onCreateViewHolder()_ and _onBindViewHolder()_ to provide custom implementation for inflating and binding custom view types.