### PR TITLE
Adapter method updates

### DIFF
--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -335,17 +335,7 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
      * @param footerViewId layout view id.
      */
     public void setFooter(@LayoutRes int footerViewId) {
-        boolean hadFooterBefore = hasFooter();
-
-        int position = getCollectionCount() + (hasHeader() ? 1 : 0);
-        footerView = LayoutInflater.from(getContext()).inflate(footerViewId, null, false);
-        setDefaultLayoutParams(footerView);
-
-        if (hadFooterBefore) {
-            notifyItemChanged(position);
-        } else {
-            notifyItemInserted(position);
-        }
+        setFooter(LayoutInflater.from(getContext()).inflate(footerViewId, null, false));
     }
 
     /**
@@ -376,16 +366,7 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
      * @param headerViewId layout view id.
      */
     public void setHeader(@LayoutRes int headerViewId) {
-        boolean hadHeaderBefore = hasHeader();
-
-        headerView = LayoutInflater.from(getContext()).inflate(headerViewId, null, false);
-        setDefaultLayoutParams(headerView);
-
-        if (hadHeaderBefore) {
-            notifyItemChanged(0);
-        } else {
-            notifyItemInserted(0);
-        }
+        setHeader(LayoutInflater.from(getContext()).inflate(headerViewId, null, false));
     }
 
     /**

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -330,44 +330,81 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     // region Headers and Footers
 
     /**
-     * Add a footer view to this adapter. If footer already exists, it will be replaced depending on the {@param shouldReplace} value.
+     * Add a footer view to this adapter. If footer already exists, it will be replaced.
      *
-     * @param footerViewId  layout view id.
-     * @param shouldReplace should we replace footer if it already exists
-     * @return true if footer was added/replaced, false otherwise.
+     * @param footerViewId layout view id.
      */
-    public boolean setFooter(@LayoutRes int footerViewId, boolean shouldReplace) {
-        if (shouldReplace || !hasFooter()) {
-            removeFooter();
-            int position = getCollectionCount() + (hasHeader() ? 1 : 0);
-            footerView = LayoutInflater.from(getContext()).inflate(footerViewId, null, false);
-            setDefaultLayoutParams(footerView);
-            notifyItemInserted(position);
-            return true;
+    public void setFooter(@LayoutRes int footerViewId) {
+        boolean hadFooterBefore = hasFooter();
+
+        int position = getCollectionCount() + (hasHeader() ? 1 : 0);
+        footerView = LayoutInflater.from(getContext()).inflate(footerViewId, null, false);
+        setDefaultLayoutParams(footerView);
+
+        if (hadFooterBefore) {
+            notifyItemChanged(position);
         } else {
-            return false;
+            notifyItemInserted(position);
         }
     }
 
     /**
      * Add a footer view to this adapter. If layout params for the {@param footerView}} are missing, default layout params will be set with
      * the {@link #setDefaultLayoutParams(View)} method.
-     * If footer already exists, it will be replaced depending on the {@param shouldReplace} value.
+     * If footer already exists, it will be replaced.
      *
-     * @param footerView    layout view
-     * @param shouldReplace should we replace footer if it already exists
+     * @param footerView layout view
      * @return true if footer was added/replaced, false otherwise.
      */
-    public boolean setFooter(View footerView, boolean shouldReplace) {
-        if (shouldReplace || !hasFooter()) {
-            removeFooter();
-            int position = getCollectionCount() + (hasHeader() ? 1 : 0);
-            this.footerView = footerView;
-            setDefaultLayoutParams(this.footerView);
-            notifyItemInserted(position);
-            return true;
+    public void setFooter(View footerView) {
+        boolean hadFooterBefore = hasFooter();
+
+        int position = getCollectionCount() + (hasHeader() ? 1 : 0);
+        this.footerView = footerView;
+        setDefaultLayoutParams(this.footerView);
+
+        if (hadFooterBefore) {
+            notifyItemChanged(position);
         } else {
-            return false;
+            notifyItemInserted(position);
+        }
+    }
+
+    /**
+     * Add a header view to this adapter. If header already exists, it will be replaced.
+     *
+     * @param headerViewId layout view id.
+     */
+    public void setHeader(@LayoutRes int headerViewId) {
+        boolean hadHeaderBefore = hasHeader();
+
+        headerView = LayoutInflater.from(getContext()).inflate(headerViewId, null, false);
+        setDefaultLayoutParams(headerView);
+
+        if (hadHeaderBefore) {
+            notifyItemChanged(0);
+        } else {
+            notifyItemInserted(0);
+        }
+    }
+
+    /**
+     * Add a header view to this adapter. If layout params for the {@param headerView}} are missing, default layout params will be set with
+     * the {@link #setDefaultLayoutParams(View)} method.
+     * *
+     *
+     * @param headerView layout view
+     */
+    public void setHeader(View headerView) {
+        boolean hadHeaderBefore = hasHeader();
+
+        this.headerView = headerView;
+        setDefaultLayoutParams(this.headerView);
+
+        if (hadHeaderBefore) {
+            notifyItemChanged(0);
+        } else {
+            notifyItemInserted(0);
         }
     }
 
@@ -390,47 +427,6 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
                         RecyclerView.LayoutParams.MATCH_PARENT);
                 view.setLayoutParams(layoutParams);
             }
-        }
-    }
-
-    /**
-     * Add a header view to this adapter. If header already exists, it will be replaced depending on the {@param shouldReplace} value.
-     *
-     * @param headerViewId  layout view id.
-     * @param shouldReplace should we replace header if it already exists
-     * @return true if header was added/replaced, false otherwise.
-     */
-    public boolean setHeader(@LayoutRes int headerViewId, boolean shouldReplace) {
-        if (shouldReplace || !hasHeader()) {
-            removeHeader();
-            headerView = LayoutInflater.from(getContext()).inflate(headerViewId, null, false);
-            setDefaultLayoutParams(headerView);
-            notifyItemInserted(0);
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * Add a header view to this adapter. If layout params for the {@param headerView}} are missing, default layout params will be set with
-     * the {@link #setDefaultLayoutParams(View)} method.
-     *
-     * If header already exists, it will be replaced depending on the {@param shouldReplace} value.
-     *
-     * @param headerView    layout view
-     * @param shouldReplace should we replace header if it already exists
-     * @return true if header was added/replaced, false otherwise.
-     */
-    public boolean setHeader(View headerView, boolean shouldReplace) {
-        if (shouldReplace || !hasHeader()) {
-            removeHeader();
-            this.headerView = headerView;
-            setDefaultLayoutParams(this.headerView);
-            notifyItemInserted(0);
-            return true;
-        } else {
-            return false;
         }
     }
 

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -330,29 +330,13 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     // region Headers and Footers
 
     /**
-     * Add a footer to this adapter.
-     * This method has higher priority than {@link #addFooter(android.view.View)}.
-     *
-     * Deprecated in version 1.1.0, use  {@link #addFooter(int footerViewId, boolean shouldReplace)  instead.
-     *
-     * @param footerViewId layout resource id
-     */
-    @Deprecated
-    public void addFooter(@LayoutRes int footerViewId) {
-        int position = getCollectionCount() + (hasHeader() ? 1 : 0);
-        footerView = LayoutInflater.from(getContext()).inflate(footerViewId, null, false);
-        setDefaultLayoutParams(footerView);
-        notifyItemInserted(position);
-    }
-
-    /**
      * Add a footer view to this adapter. If footer already exists, it will be replaced depending on the {@param shouldReplace} value.
      *
      * @param footerViewId  layout view id.
      * @param shouldReplace should we replace footer if it already exists
      * @return true if footer was added/replaced, false otherwise.
      */
-    public boolean addFooter(@LayoutRes int footerViewId, boolean shouldReplace) {
+    public boolean setFooter(@LayoutRes int footerViewId, boolean shouldReplace) {
         if (shouldReplace || !hasFooter()) {
             removeFooter();
             int position = getCollectionCount() + (hasHeader() ? 1 : 0);
@@ -366,22 +350,6 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     }
 
     /**
-     * Add a footer view to this adapter.
-     * This method has lower priority than {@link #addFooter(int)}.
-     *
-     * Deprecated in version 1.1.0, use  {@link #addFooter(View headerView, boolean shouldReplace)} instead.
-     *
-     * @param footerView layout view
-     */
-    @Deprecated
-    public void addFooter(View footerView) {
-        int position = getCollectionCount() + (hasHeader() ? 1 : 0);
-        this.footerView = footerView;
-        setDefaultLayoutParams(footerView);
-        notifyItemInserted(position);
-    }
-
-    /**
      * Add a footer view to this adapter. If layout params for the {@param footerView}} are missing, default layout params will be set with
      * the {@link #setDefaultLayoutParams(View)} method.
      * If footer already exists, it will be replaced depending on the {@param shouldReplace} value.
@@ -390,7 +358,7 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
      * @param shouldReplace should we replace footer if it already exists
      * @return true if footer was added/replaced, false otherwise.
      */
-    public boolean addFooter(View footerView, boolean shouldReplace) {
+    public boolean setFooter(View footerView, boolean shouldReplace) {
         if (shouldReplace || !hasFooter()) {
             removeFooter();
             int position = getCollectionCount() + (hasHeader() ? 1 : 0);
@@ -426,28 +394,13 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     }
 
     /**
-     * Add a header to this adapter.
-     * This method has higher priority than {@link #addHeader(android.view.View)}.
-     *
-     * Deprecated in version 1.1.0, use  {@link #addHeader(int headerViewId, boolean shouldReplace)} instead.
-     *
-     * @param headerViewId layout resource id
-     */
-    @Deprecated
-    public void addHeader(@LayoutRes int headerViewId) {
-        headerView = LayoutInflater.from(getContext()).inflate(headerViewId, null, false);
-        setDefaultLayoutParams(headerView);
-        notifyItemInserted(0);
-    }
-
-    /**
      * Add a header view to this adapter. If header already exists, it will be replaced depending on the {@param shouldReplace} value.
      *
      * @param headerViewId  layout view id.
      * @param shouldReplace should we replace header if it already exists
      * @return true if header was added/replaced, false otherwise.
      */
-    public boolean addHeader(@LayoutRes int headerViewId, boolean shouldReplace) {
+    public boolean setHeader(@LayoutRes int headerViewId, boolean shouldReplace) {
         if (shouldReplace || !hasHeader()) {
             removeHeader();
             headerView = LayoutInflater.from(getContext()).inflate(headerViewId, null, false);
@@ -460,21 +413,6 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     }
 
     /**
-     * Add a header view to this adapter.
-     * This method has lower priority than {@link #addHeader(int)}.
-     *
-     * Deprecated in version 1.1.0, use  {@link #addHeader(View headerView, boolean shouldReplace)} instead.
-     *
-     * @param headerView layout view
-     */
-    @Deprecated
-    public void addHeader(View headerView) {
-        this.headerView = headerView;
-        setDefaultLayoutParams(headerView);
-        notifyItemInserted(0);
-    }
-
-    /**
      * Add a header view to this adapter. If layout params for the {@param headerView}} are missing, default layout params will be set with
      * the {@link #setDefaultLayoutParams(View)} method.
      *
@@ -484,7 +422,7 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
      * @param shouldReplace should we replace header if it already exists
      * @return true if header was added/replaced, false otherwise.
      */
-    public boolean addHeader(View headerView, boolean shouldReplace) {
+    public boolean setHeader(View headerView, boolean shouldReplace) {
         if (shouldReplace || !hasHeader()) {
             removeHeader();
             this.headerView = headerView;
@@ -615,9 +553,8 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
 
     /**
      * Override this method if you are using custom ItemViewType and provide correct implementation.
-     * @param position
-     * @return
-     * +
+     *
+     * @return +
      */
     protected int getAdditionalItemViewType(int position) {
         return TYPE_ITEM;

--- a/testapp/src/main/java/co/infinum/testapp/activities/GridActivity.java
+++ b/testapp/src/main/java/co/infinum/testapp/activities/GridActivity.java
@@ -19,7 +19,6 @@ import co.infinum.testapp.adapters.SimpleAdapter;
 /**
  * Created by Željko Plesac on 24/11/16.
  */
-
 public class GridActivity extends AppCompatActivity implements SimpleAdapter.OnClickListener<String> {
 
     private static final List<String> ITEMS = Collections.unmodifiableList(Arrays.asList(
@@ -59,8 +58,8 @@ public class GridActivity extends AppCompatActivity implements SimpleAdapter.OnC
 
         View footerView = getLayoutInflater().inflate(R.layout.view_footer, null);
 
-        adapter.setHeader(R.layout.view_header, true);
-        adapter.setFooter(footerView, false);
+        adapter.setHeader(R.layout.view_header);
+        adapter.setFooter(footerView);
     }
 
     @Override

--- a/testapp/src/main/java/co/infinum/testapp/activities/GridActivity.java
+++ b/testapp/src/main/java/co/infinum/testapp/activities/GridActivity.java
@@ -59,8 +59,8 @@ public class GridActivity extends AppCompatActivity implements SimpleAdapter.OnC
 
         View footerView = getLayoutInflater().inflate(R.layout.view_footer, null);
 
-        adapter.addHeader(R.layout.view_header, true);
-        adapter.addFooter(footerView, false);
+        adapter.setHeader(R.layout.view_header, true);
+        adapter.setFooter(footerView, false);
     }
 
     @Override

--- a/testapp/src/main/java/co/infinum/testapp/activities/SimpleActivity.java
+++ b/testapp/src/main/java/co/infinum/testapp/activities/SimpleActivity.java
@@ -53,8 +53,8 @@ public class SimpleActivity extends AppCompatActivity implements SimpleAdapter.O
         adapter.setOnClickListener(this);
         recyclerView.setAdapter(adapter);
 
-        adapter.setHeader(R.layout.view_header, false);
-        adapter.setFooter(R.layout.view_footer, false);
+        adapter.setHeader(R.layout.view_header);
+        adapter.setFooter(R.layout.view_footer);
 
         Handler handler = new Handler();
         handler.postDelayed(new Runnable() {
@@ -65,15 +65,6 @@ public class SimpleActivity extends AppCompatActivity implements SimpleAdapter.O
                 }
             }
         }, 5000);
-
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                if (!isFinishing()) {
-                    adapter.setHeader(R.layout.view_footer, true);
-                }
-            }
-        }, 7000);
     }
 
     @Override

--- a/testapp/src/main/java/co/infinum/testapp/activities/SimpleActivity.java
+++ b/testapp/src/main/java/co/infinum/testapp/activities/SimpleActivity.java
@@ -53,8 +53,8 @@ public class SimpleActivity extends AppCompatActivity implements SimpleAdapter.O
         adapter.setOnClickListener(this);
         recyclerView.setAdapter(adapter);
 
-        adapter.addHeader(R.layout.view_header, false);
-        adapter.addFooter(R.layout.view_footer, false);
+        adapter.setHeader(R.layout.view_header, false);
+        adapter.setFooter(R.layout.view_footer, false);
 
         Handler handler = new Handler();
         handler.postDelayed(new Runnable() {
@@ -70,7 +70,7 @@ public class SimpleActivity extends AppCompatActivity implements SimpleAdapter.O
             @Override
             public void run() {
                 if (!isFinishing()) {
-                    adapter.addHeader(R.layout.view_footer, true);
+                    adapter.setHeader(R.layout.view_footer, true);
                 }
             }
         }, 7000);


### PR DESCRIPTION
Removed deprecated methods in order to prepare Mjolnir for 2.0.0 release.

Also, I've renamed addFooter/addHeader methods to setFooter/setHeader, as they are more precise - if we use "add" keyword, it immediately signals that we are supporting multiple headers/footers, which is still not the case.