### PR TITLE
Write better documentation for addFooter and addHeader

### DIFF
--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -343,6 +343,11 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
 
     /**
      * Add a footer view to this adapter. If footer already exists, it will be replaced depending on the {@param shouldReplace} value.
+     * <p>
+     * Note: addFooter should be called only after {@link MjolnirRecyclerView#setAdapter(RecyclerView.Adapter)} otherwise the default
+     * layout params wont apply to this view. For more info about the default layout params check {@link #setDefaultLayoutParams(View)}
+     * documentation.
+     *
      *
      * @param footerViewId  layout view id.
      * @param shouldReplace should we replace footer if it already exists
@@ -380,7 +385,12 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
     /**
      * Add a footer view to this adapter. If layout params for the {@param footerView}} are missing, default layout params will be set with
      * the {@link #setDefaultLayoutParams(View)} method.
+     *
      * If footer already exists, it will be replaced depending on the {@param shouldReplace} value.
+     * <p>
+     * Note: addFooter should be called only after {@link MjolnirRecyclerView#setAdapter(RecyclerView.Adapter)} otherwise the default
+     * layout params wont apply to this view. For more info about the default layout params check {@link #setDefaultLayoutParams(View)}
+     * documentation.
      *
      * @param footerView    layout view
      * @param shouldReplace should we replace footer if it already exists
@@ -438,6 +448,10 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
 
     /**
      * Add a header view to this adapter. If header already exists, it will be replaced depending on the {@param shouldReplace} value.
+     * <p>
+     * Note: addHeader should be called only after {@link MjolnirRecyclerView#setAdapter(RecyclerView.Adapter)} otherwise the default
+     * layout params wont apply to this view. For more info about the default layout params check {@link #setDefaultLayoutParams(View)}
+     * documentation.
      *
      * @param headerViewId  layout view id.
      * @param shouldReplace should we replace header if it already exists
@@ -475,6 +489,10 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
      * the {@link #setDefaultLayoutParams(View)} method.
      *
      * If header already exists, it will be replaced depending on the {@param shouldReplace} value.
+     * <p>
+     * Note: addHeader should be called only after {@link MjolnirRecyclerView#setAdapter(RecyclerView.Adapter)} otherwise the default
+     * layout params wont apply to this view. For more info about the default layout params check {@link #setDefaultLayoutParams(View)}
+     * documentation.
      *
      * @param headerView    layout view
      * @param shouldReplace should we replace header if it already exists

--- a/testapp/src/main/java/co/infinum/testapp/activities/SimpleActivity.java
+++ b/testapp/src/main/java/co/infinum/testapp/activities/SimpleActivity.java
@@ -51,11 +51,11 @@ public class SimpleActivity extends AppCompatActivity implements SimpleAdapter.O
 
         adapter = new SimpleAdapter(this);
         adapter.setOnClickListener(this);
-        recyclerView.setAdapter(adapter);
 
         adapter.addHeader(R.layout.view_header, false);
         adapter.addFooter(R.layout.view_footer, false);
 
+        recyclerView.setAdapter(adapter);
         Handler handler = new Handler();
         handler.postDelayed(new Runnable() {
             @Override


### PR DESCRIPTION
Write better documentation for `addFooter` and `addHeader` methods. 
Code changes in the SimpleActivity is just to demonstrate how the default layout params are not set if the methods are called before `setAdapter`. The code changes in `SimpleActivity` can be discarded after a successful PR review.

The reason why the default params are not set when the methods are called before setting the adapter is because the `getLayoutManager() ` is null in that case.