### PR TITLE
ItemViewType fixes

### DIFF
--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -556,7 +556,7 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
      * Override this method if you are using custom ItemViewType and provide correct implementation.
      * @param adapterPosition current adapter position
      * @param itemPosition current item positions, which is different from {@param adapterPosition} if adapter has header view.
-     * @return
+     * @return item view type.
      */
     protected int getAdditionalItemViewType(int adapterPosition, int itemPosition) {
         return TYPE_ITEM;

--- a/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
+++ b/mjolnirrecyclerview/src/main/java/co/infinum/mjolnirrecyclerview/MjolnirRecyclerAdapter.java
@@ -549,18 +549,18 @@ public abstract class MjolnirRecyclerAdapter<E> extends RecyclerView.Adapter<Mjo
             return TYPE_FOOTER;
         }
 
-        return getAdditionalItemViewType(position);
+        return getAdditionalItemViewType(position, calculateIndex(position, true));
     }
 
     /**
      * Override this method if you are using custom ItemViewType and provide correct implementation.
-     *
-     * @return +
+     * @param adapterPosition current adapter position
+     * @param itemPosition current item positions, which is different from {@param adapterPosition} if adapter has header view.
+     * @return
      */
-    protected int getAdditionalItemViewType(int position) {
+    protected int getAdditionalItemViewType(int adapterPosition, int itemPosition) {
         return TYPE_ITEM;
     }
-
 
     public interface OnClickListener<E> {
 


### PR DESCRIPTION
This PR fixes problems described in #52.

We are introducing new method parameter to getAdditionalItemViewType() called itemPosition, which notifies the user about item index in item collection.

By using the 2 proposed variables, we can get notified about ItemViewType position in adapter and item collection.